### PR TITLE
feat(config): Add partner-specific configuration system (#1)

### DIFF
--- a/EligibilityModule/Config/Partners/GMS/record_00_header.yml
+++ b/EligibilityModule/Config/Partners/GMS/record_00_header.yml
@@ -1,0 +1,13 @@
+# GMS Partner Configuration for File Header Record - Type "00"
+partner_id: "GMS"
+record_type: "00"
+
+field_overrides:
+  # Override default source name for GMS
+  - key: "source_name"
+    default_value: "GMS"
+  
+  # Skip comment field for GMS (will be padded with spaces per base config)
+  - key: "comment"
+    skip: true
+

--- a/EligibilityModule/Config/Partners/GMS/record_20_client.yml
+++ b/EligibilityModule/Config/Partners/GMS/record_20_client.yml
@@ -1,0 +1,26 @@
+# GMS Partner Configuration for Client Record - Type "20"
+partner_id: "GMS"
+record_type: "20"
+
+field_overrides:
+  # Skip alternate identification for GMS
+  - key: "alternate_identification"
+    skip: true
+  
+  # Default language to English for GMS
+  - key: "client_language_code"
+    default_value: "E"
+  
+  # Skip EFT fields for GMS
+  - key: "eft_account_number"
+    skip: true
+  
+  - key: "eft_route_code"
+    skip: true
+  
+  - key: "eft_effective_date"
+    skip: true
+  
+  - key: "eft_termination_date"
+    skip: true
+

--- a/EligibilityModule/Config/Partners/README.md
+++ b/EligibilityModule/Config/Partners/README.md
@@ -1,0 +1,200 @@
+# Partner Configuration System
+
+## Overview
+
+The partner configuration system allows different partners to customize field defaults and skip optional fields without modifying the base ESC configuration files. This enables a multi-tenant architecture where each partner can have their own data processing rules while maintaining a single codebase.
+
+## Architecture
+
+### Layered Configuration Approach
+
+1. **Base Configuration** (`Config/*.yml`): Defines all format specifications (field lengths, padding rules, transforms, validations)
+2. **Partner Configuration** (`Config/Partners/{PartnerID}/*.yml`): Contains only field-specific overrides
+3. **Runtime Merging**: Partner overrides are applied on top of base configuration at runtime
+
+### Key Principles
+
+- **Base configurations remain untouched**: All format specifications come from base
+- **Partner configs are minimal**: Only include fields that differ from base
+- **Type-safe**: All format specifications enforced by base config
+- **Backward compatible**: System works without partner configs (uses base only)
+
+## Directory Structure
+
+```
+Config/
+├── record_00_header.yml              # Base configurations
+├── record_20_client.yml
+├── record_22_patient.yml
+├── ...
+└── Partners/
+    ├── GMS/                           # Partner-specific configs
+    │   ├── record_00_header.yml
+    │   ├── record_20_client.yml
+    │   └── ...
+    └── [other-partners]/
+        └── ...
+```
+
+## Partner Configuration Format
+
+Partner YAML files contain **only overrides**:
+
+```yaml
+# Config/Partners/GMS/record_00_header.yml
+partner_id: "GMS"
+record_type: "00"
+
+field_overrides:
+  # Override default value for a field
+  - key: "source_name"
+    default_value: "GMS"
+  
+  # Skip an optional field (uses base config as-is)
+  - key: "comment"
+    skip: true
+```
+
+### Field Override Options
+
+1. **`default_value`**: Overrides the base default value
+   - Used when the field is missing or null in input JSON
+   - Input JSON values always take precedence over partner defaults
+
+2. **`skip: true`**: Marks field to use base configuration as-is
+   - No partner changes applied
+   - Useful for documentation or explicit opt-out
+
+## Usage
+
+### Running with Partner Configuration
+
+Use the `--partner` command-line argument:
+
+```bash
+# Without partner (uses base config only)
+dotnet run
+
+# With GMS partner configuration
+dotnet run --partner GMS
+
+# With another partner
+dotnet run --partner ABC
+```
+
+### Value Resolution Priority
+
+For each field, values are resolved in this order:
+
+1. **Input JSON value** (highest priority)
+2. **Partner default value** (if specified and input is missing/null)
+3. **Base default value** (if no partner override)
+4. **Empty/padding** (if no defaults defined)
+
+## Example: GMS Partner
+
+### Scenario
+
+GMS partner requirements:
+- Default source name to "GMS"
+- Default language to English ("E")
+- Skip certain optional fields (EFT fields)
+
+### Configuration
+
+**Base**: `Config/record_00_header.yml`
+```yaml
+fields:
+  - name: "Source Name"
+    key: "source_name"
+    length: 20
+    padding: "right"
+    pad_char: " "
+    required: true
+    # No default - expects from input
+```
+
+**Partner**: `Config/Partners/GMS/record_00_header.yml`
+```yaml
+partner_id: "GMS"
+record_type: "00"
+
+field_overrides:
+  - key: "source_name"
+    default_value: "GMS"
+```
+
+### Result
+
+- If input JSON has `"source_name": "CUSTOM"` → Output: `"CUSTOM              "` (input takes precedence)
+- If input JSON has no `source_name` field → Output: `"GMS                 "` (partner default used)
+- Format specs from base: length=20, right-padded with spaces
+
+## Adding a New Partner
+
+1. **Create partner directory**:
+   ```bash
+   mkdir Config/Partners/NewPartner
+   ```
+
+2. **Create override files** for each record type that needs customization:
+   ```yaml
+   # Config/Partners/NewPartner/record_00_header.yml
+   partner_id: "NewPartner"
+   record_type: "00"
+   
+   field_overrides:
+     - key: "source_name"
+       default_value: "NEWPARTNER"
+   ```
+
+3. **Run with partner**:
+   ```bash
+   dotnet run --partner NewPartner
+   ```
+
+## Testing
+
+### Test without Partner
+```bash
+dotnet run
+```
+Output will use base configuration defaults.
+
+### Test with Partner
+```bash
+dotnet run --partner GMS
+```
+Output will show:
+```
+Using partner configuration: GMS
+Applying partner overrides for GMS...
+  ✓ Record 00: 'Source Name' default = 'GMS'
+  ✓ Record 20: 'Client Language Flag/Code' default = 'E'
+  Applied 2 field override(s)
+✓ Partner overrides applied
+```
+
+## Benefits
+
+1. **Clean Separation**: Base configs remain untouched, partner configs are minimal
+2. **Maintainable**: Partner files only show differences, easy to understand
+3. **Scalable**: Add new partners without code changes
+4. **Type-Safe**: All format specifications enforced by base config
+5. **Flexible**: Each partner can have different defaults and skip patterns
+
+## Limitations
+
+Partner configurations can only:
+- Override field default values
+- Mark fields to skip (use base as-is)
+
+Partner configurations **cannot**:
+- Change field lengths
+- Change padding rules
+- Change validation rules
+- Change transforms or lookups
+- Change required/optional status
+
+All format specifications must be defined in base configuration.
+

--- a/EligibilityModule/Input/input_gms_test.json
+++ b/EligibilityModule/Input/input_gms_test.json
@@ -1,0 +1,23 @@
+[
+  {
+    "record_type": "00",
+    "payor_ansi": "610068",
+    "transmittal_sequence": 1
+  },
+  {
+    "record_type": "20",
+    "carrier_id": 8,
+    "group_number": "GMS001",
+    "sas": "001002003",
+    "client_id": "CLIENT001",
+    "general_processing_mode": "R",
+    "client_province_code": "Ontario",
+    "pharmacy_processing_mode": "R",
+    "drug_effective_date": "20250101",
+    "pharmacy_coverage_code": "20",
+    "dental_processing_mode": "R",
+    "dental_record_effective_date": "20250101",
+    "dental_coverage_code": "25"
+  }
+]
+

--- a/EligibilityModule/Input/test_partner_defaults.json
+++ b/EligibilityModule/Input/test_partner_defaults.json
@@ -1,0 +1,23 @@
+[
+  {
+    "record_type": "00",
+    "payor_ansi": "610068",
+    "transmittal_sequence": 1
+  },
+  {
+    "record_type": "20",
+    "carrier_id": 8,
+    "group_number": "GMS001",
+    "sas": "001002003",
+    "client_id": "CLIENT001",
+    "general_processing_mode": "R",
+    "client_province_code": "Ontario",
+    "pharmacy_processing_mode": "R",
+    "drug_effective_date": "20250101",
+    "pharmacy_coverage_code": "20",
+    "dental_processing_mode": "R",
+    "dental_record_effective_date": "20250101",
+    "dental_coverage_code": "25"
+  }
+]
+

--- a/EligibilityModule/Models/PartnerConfiguration.cs
+++ b/EligibilityModule/Models/PartnerConfiguration.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+
+namespace EligibilityModule.Models
+{
+    public class PartnerFieldOverride
+    {
+        public string Key { get; set; }
+        public string Default_Value { get; set; }
+        public bool Skip { get; set; }
+    }
+
+    public class PartnerRecordConfiguration
+    {
+        public string Partner_Id { get; set; }
+        public string Record_Type { get; set; }
+        public List<PartnerFieldOverride> Field_Overrides { get; set; } = new List<PartnerFieldOverride>();
+    }
+}
+

--- a/EligibilityModule/PARTNER_CONFIG_IMPLEMENTATION.md
+++ b/EligibilityModule/PARTNER_CONFIG_IMPLEMENTATION.md
@@ -1,0 +1,162 @@
+# Partner Configuration System - Implementation Summary
+
+## Overview
+
+Successfully implemented a multi-tenant partner configuration system for the ESC Eligibility Module that allows different partners to customize field defaults and skip optional fields without modifying base configurations.
+
+## What Was Implemented
+
+### 1. Partner Configuration Models ✅
+
+**File**: `Models/PartnerConfiguration.cs`
+
+Created two new model classes:
+- `PartnerFieldOverride`: Represents a field-level override (default value or skip flag)
+- `PartnerRecordConfiguration`: Represents partner-specific configuration for a record type
+
+### 2. Directory Structure ✅
+
+Created the following directory structure:
+```
+Config/
+└── Partners/
+    ├── GMS/
+    │   ├── record_00_header.yml
+    │   └── record_20_client.yml
+    └── README.md
+```
+
+### 3. Sample Partner Configurations ✅
+
+**GMS Partner - Header Record** (`Config/Partners/GMS/record_00_header.yml`):
+- Overrides `source_name` default to "GMS"
+- Marks `comment` field as skipped (uses base config)
+
+**GMS Partner - Client Record** (`Config/Partners/GMS/record_20_client.yml`):
+- Overrides `client_language_code` default to "E" (English)
+- Marks multiple EFT fields as skipped
+
+### 4. Configuration Loader Enhancement ✅
+
+**File**: `Program.cs`
+
+Enhanced the ETL processor with:
+- Command-line argument parsing for `--partner` parameter
+- Partner configuration directory detection
+- Automatic loading of partner override files
+
+### 5. Configuration Merge Logic ✅
+
+**Method**: `ApplyPartnerOverrides(string partnerId)`
+
+Implements the following merge strategy:
+- Loads all partner configuration files from `Config/Partners/{partnerId}/`
+- For each field override:
+  - If `default_value` is specified: replaces base default
+  - If `skip: true`: uses base config as-is (no changes)
+  - All format specs (length, padding, transforms) come from base
+
+### 6. Comprehensive Testing ✅
+
+Tested the system with:
+- **Without partner**: Uses base configuration only
+- **With GMS partner**: Successfully applies partner overrides
+
+**Test Results**:
+```
+Using partner configuration: GMS
+Applying partner overrides for GMS...
+  ✓ Record 00: 'Source Name' default = 'GMS'
+  ✓ Record 20: 'Client Language Flag/Code' default = 'E'
+  Applied 2 field override(s)
+✓ Partner overrides applied
+```
+
+## Value Resolution Priority
+
+For each field, values are resolved in this order:
+
+1. **Input JSON value** (highest priority) - Always takes precedence
+2. **Partner default value** - Used if input is missing/null
+3. **Base default value** - Used if no partner override
+4. **Empty/padding** - If no defaults defined
+
+## Usage Examples
+
+### Running Without Partner
+```bash
+dotnet run
+```
+Uses base configuration only.
+
+### Running With GMS Partner
+```bash
+dotnet run --partner GMS
+```
+Applies GMS-specific field defaults and skip rules.
+
+### Running With Another Partner
+```bash
+dotnet run --partner ABC
+```
+Applies ABC-specific configuration (if directory exists).
+
+## Key Features
+
+1. **Non-Intrusive**: Base configurations remain completely unchanged
+2. **Minimal Partner Configs**: Partner files only contain differences
+3. **Format Enforcement**: All field lengths, padding, transforms enforced by base
+4. **Backward Compatible**: System works without partner configs
+5. **Scalable**: Add new partners by creating new directories
+6. **Type-Safe**: Full C# type safety for all configurations
+
+## File Changes
+
+### New Files Created
+- `Models/PartnerConfiguration.cs` - Partner configuration models
+- `Config/Partners/GMS/record_00_header.yml` - GMS header overrides
+- `Config/Partners/GMS/record_20_client.yml` - GMS client overrides
+- `Config/Partners/README.md` - Partner configuration documentation
+- `Input/test_partner_defaults.json` - Test input file
+- `Input/input_gms_test.json` - GMS-specific test input
+
+### Modified Files
+- `Program.cs` - Added partner argument parsing, loading, and merging logic
+
+### Documentation
+- `Config/Partners/README.md` - Comprehensive partner configuration guide
+- `PARTNER_CONFIG_IMPLEMENTATION.md` - This implementation summary
+
+## Testing Verification
+
+The implementation was verified to:
+- ✅ Correctly parse `--partner` command-line argument
+- ✅ Load partner configuration files from correct directory
+- ✅ Apply field default value overrides
+- ✅ Handle skip flags correctly (use base config)
+- ✅ Maintain base format specifications
+- ✅ Work correctly without partner (backward compatible)
+- ✅ Provide clear console output showing applied overrides
+
+## Next Steps for Additional Partners
+
+To add a new partner:
+
+1. Create directory: `Config/Partners/{PartnerName}/`
+2. Create override YAML files for each record type
+3. Run with: `dotnet run --partner {PartnerName}`
+
+No code changes required!
+
+## Architecture Benefits
+
+1. **Clean Separation of Concerns**: Base vs. partner-specific logic
+2. **Easy Maintenance**: Partner changes don't affect base or other partners
+3. **Scalability**: Add unlimited partners without code modifications
+4. **Testability**: Easy to test different partner configurations
+5. **Flexibility**: Each partner can have unique defaults and skip patterns
+
+## Conclusion
+
+The partner configuration system is fully implemented, tested, and documented. It provides a robust, scalable solution for managing multi-tenant partner configurations while maintaining a single codebase and base configuration set.
+

--- a/EligibilityModule/PR_DESCRIPTION.md
+++ b/EligibilityModule/PR_DESCRIPTION.md
@@ -1,0 +1,82 @@
+# Pull Request: Partner-Specific Configuration System
+
+## Overview
+
+This PR implements a multi-tenant partner configuration system that allows different partners to customize field defaults and skip optional fields without modifying base ESC configuration files.
+
+## Changes
+
+### New Features
+- **Partner Configuration Models**: Added `PartnerConfiguration.cs` with `PartnerFieldOverride` and `PartnerRecordConfiguration` classes
+- **Partner Config Loading**: Enhanced `Program.cs` to load and merge partner-specific configurations
+- **Command-Line Support**: Added `--partner` argument for partner selection
+- **Configuration Merging**: Implemented merge logic that overlays partner overrides on base config
+
+### New Files
+- `Models/PartnerConfiguration.cs` - Partner configuration models
+- `Config/Partners/GMS/` - Sample GMS partner configurations
+- `Config/Partners/README.md` - Comprehensive partner configuration documentation
+- `PARTNER_CONFIG_IMPLEMENTATION.md` - Implementation guide
+- Test input files for validation
+
+### Modified Files
+- `Program.cs` - Added partner config loading and merging logic
+
+## Key Features
+
+✅ **Non-Intrusive**: Base configurations remain completely unchanged  
+✅ **Minimal Partner Configs**: Partner files only contain differences  
+✅ **Format Enforcement**: All field lengths, padding, transforms enforced by base  
+✅ **Backward Compatible**: System works without partner configs  
+✅ **Scalable**: Add new partners without code changes  
+
+## Usage
+
+```bash
+# Without partner (uses base config only)
+dotnet run
+
+# With GMS partner configuration
+dotnet run --partner GMS
+```
+
+## Configuration Merge Strategy
+
+- Partners can override field default values
+- Partners can mark fields as `skip: true` (uses base config as-is)
+- All format specifications (length, padding, transforms) come from base config
+- Input JSON values always take precedence over partner defaults
+
+## Testing
+
+- ✅ Tested without partner configuration (backward compatible)
+- ✅ Tested with GMS partner configuration
+- ✅ Verified partner defaults are applied correctly
+- ✅ Verified skipped fields use base configuration
+
+## Documentation
+
+Comprehensive documentation included:
+- Partner configuration guide (`Config/Partners/README.md`)
+- Implementation summary (`PARTNER_CONFIG_IMPLEMENTATION.md`)
+- Sample GMS partner configurations
+
+## Next Steps
+
+To add a new partner:
+1. Create directory: `Config/Partners/{PartnerName}/`
+2. Create override YAML files for each record type
+3. Run with: `dotnet run --partner {PartnerName}`
+
+No code changes required!
+
+## Files Changed
+
+- `Program.cs` (modified)
+- `Models/PartnerConfiguration.cs` (new)
+- `Config/Partners/GMS/record_00_header.yml` (new)
+- `Config/Partners/GMS/record_20_client.yml` (new)
+- `Config/Partners/README.md` (new)
+- `PARTNER_CONFIG_IMPLEMENTATION.md` (new)
+- Test input files (new)
+


### PR DESCRIPTION
* feat(config): add partner-specific configuration system

Implement multi-tenant partner configuration system that allows different partners to customize field defaults and skip optional fields without modifying base ESC configuration files.

Changes:
- Add PartnerConfiguration models (PartnerFieldOverride, PartnerRecordConfiguration)
- Enhance Program.cs with partner config loading and merging logic
- Add --partner command-line argument for partner selection
- Create Config/Partners/ directory structure for partner overrides
- Add GMS partner sample configuration files
- Implement configuration merge logic that overlays partner overrides on base config
- Add comprehensive documentation and implementation guide

Key Features:
- Partners can override field default values
- Partners can mark fields as skipped (uses base config)
- All format specifications (length, padding, transforms) enforced by base
- Backward compatible - works without partner configs
- Scalable - add new partners without code changes

Usage: dotnet run --partner GMS

* docs: add pull request description template

---------