### PR TITLE
Fix field format inconsistencies in record_5.yml

### DIFF
--- a/ExperienceModule/Config/Records/DentalPreDetermination/record_5.yml
+++ b/ExperienceModule/Config/Records/DentalPreDetermination/record_5.yml
@@ -182,7 +182,7 @@ fields:
   start: 146
   end: 151
   length: 6
-  format: 9(6.2)
+  format: 9(6,2)
   description: Deductible applied to the lab eligible amount
 - field_number: '020'
   name: Lab Benefit amount
@@ -233,7 +233,7 @@ fields:
   start: 175
   end: 180
   length: 6
-  format: 9(6.2)
+  format: 9(6,2)
   description: Deductible applied to the expense eligible amount
 - field_number: '025'
   name: Expense Benefit amount
@@ -405,7 +405,7 @@ fields:
   start: 348
   end: 353
   length: 6
-  format: 9(6.2)
+  format: 9(6,2)
   description: Cutback amount due to adjudication rule
 - field_number: '044'
   name: Fee guide amount


### PR DESCRIPTION
## Summary
Fixes format inconsistencies in `Config/Records/DentalPreDetermination/record_5.yml` to match specification requirements.

## Changes
- **Field 019 (Lab Deductible amount)**: Changed format from `9(6.2)` to `9(6,2)`
- **Field 024 (Expense Deductible amount)**: Changed format from `9(6.2)` to `9(6,2)`
- **Field 043 (Rule Cutback amount)**: Changed format from `9(6.2)` to `9(6,2)`

## Issue
All numeric format fields now use comma separator `9(6,2)` instead of period `9(6.2)` to match the Dental Predetermination File Layout specification (THBM).

## Related Task
This PR addresses task: **6. Fix Field Format Issues** from the "Fix Experience Dental PreDetermination" work item.

## Verification
- ✅ No linting errors
- ✅ All format fields verified to use correct comma separator
- ✅ Changes align with specification requirements

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes numeric format to use comma delimiter per spec.
> 
> - Updates `format` from `9(6.2)` to `9(6,2)` for fields `019` (lab_deductible_amount), `024` (expense_deductible_amount), and `043` (rule_cutback_amount) in `ExperienceModule/Config/Records/DentalPreDetermination/record_5.yml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d5533a9bb248975de568d65b86e8398233915b9e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->